### PR TITLE
Fix: Croniter removed version 3.26. 3.29 is latest

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     version='0.0.1',
     packages=find_packages(),
     install_requires=[
-        'croniter==0.3.26',
+        'croniter==0.3.29',
         'SQLAlchemy>=1.2.16'
     ],
     extras_require={


### PR DESCRIPTION
# Motivation

```
Cloning into 'schedulable'...
remote: Enumerating objects: 10, done.        
remote: Counting objects: 100% (10/10), done.        
remote: Compressing objects: 100% (8/8), done.        
remote: Total 10 (delta 0), reused 10 (delta 0), pack-reused 0        
Receiving objects: 100% (10/10), 4.04 KiB | 0 bytes/s, done.
Branch initial-code set up to track remote branch initial-code from origin.
Switched to a new branch 'initial-code'
Obtaining file:///git/schedulable
Collecting croniter==0.3.26 (from schedulable==0.0.1)
  Could not find a version that satisfies the requirement croniter==0.3.26 (from schedulable==0.0.1) (from versions: 0.1.4.macosx-10.5-i386, 0.1.1, 0.1.2, 0.1.3, 0.1.4, 0.1.5, 0.1.6, 0.2.0, 0.2.2, 0.2.4, 0.2.5, 0.2.7, 0.3.0, 0.3.1, 0.3.2, 0.3.3, 0.3.4, 0.3.5, 0.3.6, 0.3.7, 0.3.8, 0.3.9, 0.3.10, 0.3.11, 0.3.12, 0.3.13, 0.3.14, 0.3.15, 0.3.16, 0.3.17, 0.3.18, 0.3.19, 0.3.20, 0.3.22, 0.3.23, 0.3.24, 0.3.25, 0.3.28, 0.3.29)
No matching distribution found for croniter==0.3.26 (from schedulable==0.0.1)
```

https://pypi.org/project/croniter/

```
Changelog
0.3.29 (2019-03-26)
0.3.25 (2018-08-07)
0.3.24 (2018-06-20)
0.3.23 (2018-05-23)
...
```

## Suggested Musical Pairing

Q Radio